### PR TITLE
update the version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: mdbook
-version: 'v0.0.28'
+version: '0.0.28'
 summary: Create book from markdown files
 description: |
   mdBook is a utility to create modern online books from Markdown files.


### PR DESCRIPTION
In this case, upstream is not using the convention of prefixing versions with a `v`.